### PR TITLE
Basic test suite for contacts

### DIFF
--- a/contact_map/__init__.py
+++ b/contact_map/__init__.py
@@ -1,6 +1,7 @@
 from contact_map import (
-    ContactMap, ContactFrequency, ContactDifference, NearestAtoms,
-    MinimumDistanceCounter
+    ContactMap, ContactFrequency, ContactDifference
 )
+
+from min_dist import NearestAtoms, MinimumDistanceCounter
 
 # import concurrence

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -5,10 +5,10 @@ Contact map analysis.
 # Licensed under LGPL, version 2.1 or greater
 import collections
 import itertools
+import pickle
 import scipy
 import pandas as pd
 import mdtraj as md
-import pickle
 
 # TODO:
 # * switch to something where you can define the haystack -- the trick is to
@@ -384,6 +384,7 @@ class ContactFrequency(ContactObject):
 
     @property
     def n_frames(self):
+        """Number of frames in the mapped trajectory"""
         return self._n_frames
 
     @property

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -209,7 +209,7 @@ class ContactObject(object):
         try:
             res_B_idx = res_B.index
         except AttributeError:
-            resB_idx = res_B
+            res_B_idx = res_B
             res_B = self.topology.residue(res_B_idx)
         atom_idxs_A = set(atom.index for atom in res_A.atoms)
         atom_idxs_B = set(atom.index for atom in res_B.atoms)

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -148,9 +148,9 @@ class ContactObject(object):
         # all inits required: no defaults for abstract class!
         self._topology = topology
         if query is None:
-            query = topology.select("not water and not symbol == 'H'")
+            query = topology.select("not water and symbol != 'H'")
         if haystack is None:
-            haystack = topology.select("not water and not symbol == 'H'")
+            haystack = topology.select("not water and symbol != 'H'")
         # make things private and accessible through read-only properties so
         # they don't get accidentally changed after analysis
         self._cutoff = cutoff

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -40,59 +40,6 @@ def residue_neighborhood(residue, n=1):
     # good, and it only gets run once per residue
     return [idx for idx in neighborhood if idx in chain]
 
-class NearestAtoms(object):
-    def __init__(self, trajectory, cutoff, frame_number=0):
-        # TODO: add support for a subset of all atoms with `atoms`
-        self.cutoff = cutoff
-        self.frame_number = frame_number
-        neighborlist = md.compute_neighborlist(trajectory, self.cutoff,
-                                               self.frame_number)
-        frame = trajectory[frame_number]
-        self.nearest = {}
-        self.nearest_distance = {}
-        for (atom, neighbors) in enumerate(neighborlist):
-            pairs = itertools.product([atom], neighbors)
-            distances = md.compute_distances(frame, pairs)[0]  # 0th frame
-            nearest = sorted(zip(distances, neighbors))[0]
-            self.nearest[atom] = nearest[1]
-            self.nearest_distance[atom] = nearest[0]
-
-    @property
-    def sorted_distances(self):
-        listed = [(atom, self.nearest[atom], dist)
-                  for (atom, dist) in list(self.nearest_distance.items())]
-        return sorted(listed, key=lambda tup: tup[2])
-
-class MinimumDistanceCounter(object):
-    # count how many times each atom pair has minimum distance
-    def __init__(self, trajectory, query, haystack, cutoff=0.45):
-        self.atom_pairs = list(itertools.product(query, haystack))
-        distances = md.compute_distances(trajectory,
-                                         atom_pairs=self.atom_pairs)
-        self._min_pairs = distances.argmin(axis=1)
-        self.minimum_distances = distances.min(axis=1)
-        self.topology = trajectory.topology
-        self.cutoff = cutoff
-
-    def _remap(self, pair_number):
-        pair = self.atom_pairs[pair_number]
-        return (self.topology.atom(pair[0]), self.topology.atom(pair[1]))
-
-    @property
-    def atom_history(self):
-        return [self._remap(k) for k in self._min_pairs]
-
-    @property
-    def atom_count(self):
-        return collections.Counter(self.atom_history)
-
-    @property
-    def residue_history(self):
-        return [(a[0].residue, a[1].residue) for a in self.atom_history]
-
-    @property
-    def residue_count(self):
-        return collections.Counter(self.residue_history)
 
 class ContactCount(object):
     def __init__(self, counter, object_f, n_x, n_y):

--- a/contact_map/min_dist.py
+++ b/contact_map/min_dist.py
@@ -1,0 +1,55 @@
+import mdtraj as md
+
+class NearestAtoms(object):
+    def __init__(self, trajectory, cutoff, frame_number=0):
+        # TODO: add support for a subset of all atoms with `atoms`
+        self.cutoff = cutoff
+        self.frame_number = frame_number
+        neighborlist = md.compute_neighborlist(trajectory, self.cutoff,
+                                               self.frame_number)
+        frame = trajectory[frame_number]
+        self.nearest = {}
+        self.nearest_distance = {}
+        for (atom, neighbors) in enumerate(neighborlist):
+            pairs = itertools.product([atom], neighbors)
+            distances = md.compute_distances(frame, pairs)[0]  # 0th frame
+            nearest = sorted(zip(distances, neighbors))[0]
+            self.nearest[atom] = nearest[1]
+            self.nearest_distance[atom] = nearest[0]
+
+    @property
+    def sorted_distances(self):
+        listed = [(atom, self.nearest[atom], dist)
+                  for (atom, dist) in list(self.nearest_distance.items())]
+        return sorted(listed, key=lambda tup: tup[2])
+
+class MinimumDistanceCounter(object):
+    # count how many times each atom pair has minimum distance
+    def __init__(self, trajectory, query, haystack, cutoff=0.45):
+        self.atom_pairs = list(itertools.product(query, haystack))
+        distances = md.compute_distances(trajectory,
+                                         atom_pairs=self.atom_pairs)
+        self._min_pairs = distances.argmin(axis=1)
+        self.minimum_distances = distances.min(axis=1)
+        self.topology = trajectory.topology
+        self.cutoff = cutoff
+
+    def _remap(self, pair_number):
+        pair = self.atom_pairs[pair_number]
+        return (self.topology.atom(pair[0]), self.topology.atom(pair[1]))
+
+    @property
+    def atom_history(self):
+        return [self._remap(k) for k in self._min_pairs]
+
+    @property
+    def atom_count(self):
+        return collections.Counter(self.atom_history)
+
+    @property
+    def residue_history(self):
+        return [(a[0].residue, a[1].residue) for a in self.atom_history]
+
+    @property
+    def residue_count(self):
+        return collections.Counter(self.residue_history)

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -1,3 +1,4 @@
+import os
 import collections
 import itertools
 import pytest
@@ -125,7 +126,11 @@ class TestContactMap(object):
         assert beauty_idx == truth
 
     def test_saving(self, idx):
-        pytest.skip()
+        m = self.maps[idx]
+        m.save_to_file("test_file.p")
+        m2 = ContactMap.from_file("test_file.p")
+        assert m.atom_contacts.counter == m2.atom_contacts.counter
+        os.remove("test_file.p")
 
 
 class TestContactFrequency(object):

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -134,10 +134,30 @@ class TestContactMap(object):
 
 class TestContactFrequency(object):
     def setup(self):
-        self.map = ContactFrequency(traj,
+        self.map = ContactFrequency(trajectory=traj,
                                     cutoff=0.075,
                                     n_neighbors_ignored=0)
-        # TODO: add in expected counters here
+        self.expected_atom_contact_count = {
+            frozenset([0, 8]): 1,
+            frozenset([0, 9]): 1,
+            frozenset([1, 4]): 4,
+            frozenset([1, 5]): 1,
+            frozenset([1, 8]): 1,
+            frozenset([1, 9]): 1,
+            frozenset([4, 6]): 5,
+            frozenset([4, 7]): 2,
+            frozenset([4, 8]): 1,
+            frozenset([5, 6]): 5,
+            frozenset([5, 7]): 2,
+            frozenset([5, 8]): 1
+        }
+        self.expected_residue_contact_count = {
+            frozenset([0, 2]): 5,
+            frozenset([0, 4]): 1,
+            frozenset([2, 3]): 5,
+            frozenset([2, 4]): 1
+        }
+        self.expected_n_frames = 5
         pass
 
     def test_initialization(self):
@@ -151,10 +171,29 @@ class TestContactFrequency(object):
             assert ignored_atoms == set([a.index for a in res.atoms])
 
     def test_counters(self):
-        pytest.skip()
+        assert self.map.n_frames == self.expected_n_frames
+
+        atom_contacts = self.map.atom_contacts
+        expected_atom_contacts = {
+            k: float(v) / self.expected_n_frames
+            for (k, v) in self.expected_atom_contact_count.items()
+        }
+        assert atom_contacts.counter == expected_atom_contacts
+
+        residue_contacts = self.map.residue_contacts
+        expected_residue_contacts = {
+            k: float(v) / self.expected_n_frames
+            for (k, v) in self.expected_residue_contact_count.items()
+        }
+        assert residue_contacts.counter == expected_residue_contacts
 
     def test_frames_parameter(self):
         # test that the frames parameter in initialization works
+        frames = [1, 3, 4]
+        contacts = ContactFrequency(trajectory=traj,
+                                    cutoff=0.075,
+                                    n_neighbors_ignored=0,
+                                    frames=frames)
         pytest.skip()
 
     def test_saving(self):
@@ -220,7 +259,7 @@ class TestContactDifference(object):
 
         expected_atoms_1 = counter_of_inner_list(expected_atom_diff)
         # add the zeros
-        expected_atoms_1.update({frozenset(pair): 0 
+        expected_atoms_1.update({frozenset(pair): 0
                                  for pair in expected_atom_common})
         assert diff_1.atom_contacts.counter == expected_atoms_1
         expected_atoms_2 = {k: -v for (k, v) in expected_atoms_1.items()}
@@ -230,7 +269,7 @@ class TestContactDifference(object):
         expected_residues_1.update({frozenset(pair): 0
                                     for pair in expected_residue_common})
         assert diff_1.residue_contacts.counter == expected_residues_1
-        expected_residues_2 = {k: -v 
+        expected_residues_2 = {k: -v
                                for (k, v) in expected_residues_1.items()}
         assert diff_2.residue_contacts.counter == expected_residues_2
 

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -194,7 +194,36 @@ class TestContactFrequency(object):
                                     cutoff=0.075,
                                     n_neighbors_ignored=0,
                                     frames=frames)
-        pytest.skip()
+        expected_atom_raw_count = {
+            frozenset([0, 8]): 1,
+            frozenset([0, 9]): 1,
+            frozenset([1, 4]): 2,
+            frozenset([1, 5]): 1,
+            frozenset([1, 8]): 1,
+            frozenset([1, 9]): 1,
+            frozenset([4, 6]): 3,
+            frozenset([4, 7]): 2,
+            frozenset([4, 8]): 1,
+            frozenset([5, 6]): 3,
+            frozenset([5, 7]): 2,
+            frozenset([5, 8]): 1
+        }
+        expected_residue_raw_count = {
+            frozenset([0, 2]): 3,
+            frozenset([0, 4]): 1,
+            frozenset([2, 3]): 3,
+            frozenset([2, 4]): 1
+        }
+
+        expected_atom_count = {
+            k: v/3.0 for (k, v) in expected_atom_raw_count.items()
+        }
+        assert contacts.atom_contacts.counter == expected_atom_count
+
+        expected_residue_count = {
+            k: v/3.0 for (k, v) in expected_residue_raw_count.items()
+        }
+        assert contacts.residue_contacts.counter == expected_residue_count
 
     def test_saving(self):
         m = self.map

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -17,46 +17,95 @@ def test_residue_neighborhood():
             len_n = 2*n + 1 - from_top - from_bottom
             assert len(residue_neighborhood(res, n=n)) == len_n
 
+def counter_of_inner_list(ll):
+    return collections.Counter([frozenset(i) for i in ll])
 
+def index_pairs_to_atom(ll, topology):
+    return [frozenset([topology.atom(j) for j in i]) for i in ll]
+
+def index_pairs_to_residue(ll, topology):
+    return [frozenset([topology.residue(j) for j in i]) for i in ll]
+
+@pytest.mark.parametrize("idx", [0, 4])
 class TestContactMap(object):
     def setup(self):
+        self.topology = traj.topology
         self.map0 = ContactMap(traj[0], cutoff=0.075, n_neighbors_ignored=0)
         self.map4 = ContactMap(traj[4], cutoff=0.075, n_neighbors_ignored=0)
+        self.maps = {0: self.map0, 4: self.map4}
 
-    def test_setup(self):
-        for m in [self.map0, self.map4]:
-            assert set(m.query) == set(range(10))
-            assert set(m.haystack) == set(range(10))
-            assert m.n_neighbors_ignored == 0
-            for res in m.topology.residues:
-                ignored_atoms = m.residue_ignore_atom_idxs[res.index]
-                assert ignored_atoms == set([a.index for a in res.atoms])
-
-    def test_contact_map(self):
-        # this tests the internal structure contact map object; note that
-        # this only underscored attributes, so this test can change
-        expected_atom_contacts = {
+        self.expected_atom_contacts = {
             self.map0: [[1, 4], [4, 6], [5, 6]],
             self.map4: [[0, 9], [0, 8], [1, 8], [1, 9], [1, 4], [8, 4],
                         [8, 5], [4, 6], [4, 7], [5, 6], [5, 7]]
         }
 
-        expected_residue_contacts = {
+        self.expected_residue_contacts = {
             self.map0: [[0, 2], [2, 3]],
             self.map4: [[0, 2], [2, 3], [0, 4], [2, 4]]
         }
-        for m, contacts in expected_atom_contacts.items():
-            expected = collections.Counter([frozenset(c) for c in contacts])
-            assert m._atom_contacts == expected
-        for m, contacts in expected_residue_contacts.items():
-            expected = collections.Counter([frozenset(c) for c in contacts])
-            assert m._residue_contacts == expected
 
-    def test_atom_contacts(self):
+    def test_setup(self, idx):
+        m = self.maps[idx]
+        assert set(m.query) == set(range(10))
+        assert set(m.haystack) == set(range(10))
+        assert m.n_neighbors_ignored == 0
+        assert m.topology == self.topology
+        for res in m.topology.residues:
+            ignored_atoms = m.residue_ignore_atom_idxs[res.index]
+            assert ignored_atoms == set([a.index for a in res.atoms])
+
+    def test_contact_map(self, idx):
+        # this tests the internal structure contact map object; note that
+        # this only underscored attributes, so this test can change
+        m = self.maps[idx]
+        expected = counter_of_inner_list(self.expected_atom_contacts[m])
+        assert m._atom_contacts == expected
+        assert m.atom_contacts.counter == expected
+        expected = counter_of_inner_list(self.expected_residue_contacts[m])
+        assert m._residue_contacts == expected
+        assert m.residue_contacts.counter == expected
+
+    def test_with_ignores(self, idx):
         pytest.skip()
 
-    def test_residue_contacts(self):
+    def test_most_common_atoms_for_residue(self, idx):
         pytest.skip()
+
+    def test_most_common_atoms_for_contact(self, idx):
+        pytest.skip()
+
+    def test_saving(self, idx):
+        pytest.skip()
+
+
+class TestContactCount(object):
+    def setup(self):
+        self.map = ContactMap(traj[0], cutoff=0.075, n_neighbors_ignored=0)
+        self.topology = self.map.topology
+        self.atom_contacts = self.map.atom_contacts
+        self.residue_contacts = self.map.residue_contacts
+
+    def test_initialization(self):
+        assert self.atom_contacts._object_f == self.topology.atom
+        assert self.atom_contacts.n_x == self.topology.n_atoms
+        assert self.atom_contacts.n_y == self.topology.n_atoms
+        assert self.residue_contacts._object_f == self.topology.residue
+        assert self.residue_contacts.n_x == self.topology.n_residues
+        assert self.residue_contacts.n_y == self.topology.n_residues
+
+    def test_sparse_matrix(self):
+        pytest.skip()
+
+    def test_df(self):
+        pytest.skip()
+
+    def test_most_common(self):
+        pytest.skip()
+
+    def test_most_common_idx(self):
+        pytest.skip()
+
 
 
 

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -1,7 +1,7 @@
-import pytest
-import mdtraj as md
 import collections
 import itertools
+import pytest
+import mdtraj as md
 from contact_map.contact_map import ContactMap, residue_neighborhood
 
 traj = md.load("./trajectory.pdb")
@@ -45,7 +45,7 @@ class TestContactMap(object):
             self.map4: [[0, 2], [2, 3], [0, 4], [2, 4]]
         }
 
-    def test_setup(self, idx):
+    def test_initialization(self, idx):
         m = self.maps[idx]
         assert set(m.query) == set(range(10))
         assert set(m.haystack) == set(range(10))
@@ -55,9 +55,8 @@ class TestContactMap(object):
             ignored_atoms = m.residue_ignore_atom_idxs[res.index]
             assert ignored_atoms == set([a.index for a in res.atoms])
 
-    def test_contact_map(self, idx):
-        # this tests the internal structure contact map object; note that
-        # this only underscored attributes, so this test can change
+    def test_counters(self, idx):
+        # tests the counters generated in the contact_map method
         m = self.maps[idx]
         expected = counter_of_inner_list(self.expected_atom_contacts[m])
         assert m._atom_contacts == expected
@@ -67,20 +66,88 @@ class TestContactMap(object):
         assert m.residue_contacts.counter == expected
 
     def test_with_ignores(self, idx):
-        pytest.skip()
+        m = ContactMap(traj[idx], cutoff=0.075, n_neighbors_ignored=1)
+        expected_atom_contacts = {
+            0: [[1, 4]],
+            4: [[0, 9], [0, 8], [1, 8], [1, 9], [1, 4], [8, 4], [8, 5]]
+        }
+        expected_residue_contacts = {
+            0: [[0, 2]],
+            4: [[0, 2], [0, 4], [2, 4]]
+        }
+
+        expected = counter_of_inner_list(expected_atom_contacts[idx])
+        assert m._atom_contacts == expected
+        assert m.atom_contacts.counter == expected
+
+        expected = counter_of_inner_list(expected_residue_contacts[idx])
+        assert m._residue_contacts == expected
+        assert m.residue_contacts.counter == expected
 
     def test_most_common_atoms_for_residue(self, idx):
-        pytest.skip()
+        m = self.maps[idx]
+        top = self.topology
+        expected_atom_indices_for_res_2 = {  # atoms 4, 5
+            self.map0: {4: [1, 6], 5: [6]},
+            self.map4: {4: [1, 8, 6, 7], 5: [6, 7, 8]}
+        }
+
+        most_common_atoms = m.most_common_atoms_for_residue(top.residue(2))
+        most_common_idx = m.most_common_atoms_for_residue(2)
+
+        beauty = {frozenset(ll[0]): ll[1] for ll in most_common_atoms}
+        beauty_idx = {frozenset(ll[0]): ll[1] for ll in most_common_idx}
+        truth = {frozenset([top.atom(k), top.atom(a)]): 1
+                 for (k, v) in expected_atom_indices_for_res_2[m].items()
+                 for a in v}
+
+        assert beauty == truth
+        assert beauty_idx == truth
 
     def test_most_common_atoms_for_contact(self, idx):
-        pytest.skip()
+        m = self.maps[idx]
+        top = self.topology
+        expected_atom_indices_contact_0_2 = {
+            self.map0: [[1, 4]],
+            self.map4: [[1, 4]]
+        }
+
+        contact_pair = [top.residue(0), top.residue(2)]
+        most_common_atoms = m.most_common_atoms_for_contact(contact_pair)
+        most_common_idx = m.most_common_atoms_for_contact([0, 2])
+
+        beauty = {frozenset(ll[0]): ll[1] for ll in most_common_atoms}
+        beauty_idx = {frozenset(ll[0]): ll[1] for ll in most_common_idx}
+        truth = {frozenset([top.atom(a) for a in ll]): 1 
+                 for ll in expected_atom_indices_contact_0_2[m]}
+
+        assert beauty == truth
+        assert beauty_idx == truth
 
     def test_saving(self, idx):
         pytest.skip()
 
 
+class TestContactFrequency(object):
+    def setup(self):
+        pass
+
+    def test_counters(self):
+        pytest.skip()
+
+    def test_saving(self):
+        pytest.skip()
+
+    def test_most_common_atoms_for_residue(self):
+        pytest.skip()
+
+    def test_most_common_atoms_for_contact(self):
+        pytest.skip()
+
+
 class TestContactCount(object):
     def setup(self):
+        # TODO: this should be based on the ContactFrequency
         self.map = ContactMap(traj[0], cutoff=0.075, n_neighbors_ignored=0)
         self.topology = self.map.topology
         self.atom_contacts = self.map.atom_contacts
@@ -107,7 +174,5 @@ class TestContactCount(object):
         pytest.skip()
 
 
-
-
-class TestContactFrequency(object):
+class TestContactDifference(object):
     pass

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -1,0 +1,64 @@
+import pytest
+import mdtraj as md
+import collections
+import itertools
+from contact_map.contact_map import ContactMap, residue_neighborhood
+
+traj = md.load("./trajectory.pdb")
+
+def test_residue_neighborhood():
+    top = traj.topology
+    residues = list(top.residues)
+    for res in residues:
+        assert residue_neighborhood(res, n=0) == [res.index]
+        for n in range(5):
+            from_bottom = -min(0, res.index - n)
+            from_top = max(0, res.index + n - (len(residues) - 1))
+            len_n = 2*n + 1 - from_top - from_bottom
+            assert len(residue_neighborhood(res, n=n)) == len_n
+
+
+class TestContactMap(object):
+    def setup(self):
+        self.map0 = ContactMap(traj[0], cutoff=0.075, n_neighbors_ignored=0)
+        self.map4 = ContactMap(traj[4], cutoff=0.075, n_neighbors_ignored=0)
+
+    def test_setup(self):
+        for m in [self.map0, self.map4]:
+            assert set(m.query) == set(range(10))
+            assert set(m.haystack) == set(range(10))
+            assert m.n_neighbors_ignored == 0
+            for res in m.topology.residues:
+                ignored_atoms = m.residue_ignore_atom_idxs[res.index]
+                assert ignored_atoms == set([a.index for a in res.atoms])
+
+    def test_contact_map(self):
+        # this tests the internal structure contact map object; note that
+        # this only underscored attributes, so this test can change
+        expected_atom_contacts = {
+            self.map0: [[1, 4], [4, 6], [5, 6]],
+            self.map4: [[0, 9], [0, 8], [1, 8], [1, 9], [1, 4], [8, 4],
+                        [8, 5], [4, 6], [4, 7], [5, 6], [5, 7]]
+        }
+
+        expected_residue_contacts = {
+            self.map0: [[0, 2], [2, 3]],
+            self.map4: [[0, 2], [2, 3], [0, 4], [2, 4]]
+        }
+        for m, contacts in expected_atom_contacts.items():
+            expected = collections.Counter([frozenset(c) for c in contacts])
+            assert m._atom_contacts == expected
+        for m, contacts in expected_residue_contacts.items():
+            expected = collections.Counter([frozenset(c) for c in contacts])
+            assert m._residue_contacts == expected
+
+    def test_atom_contacts(self):
+        pytest.skip()
+
+    def test_residue_contacts(self):
+        pytest.skip()
+
+
+
+class TestContactFrequency(object):
+    pass

--- a/contact_map/tests/trajectory.pdb
+++ b/contact_map/tests/trajectory.pdb
@@ -1,0 +1,62 @@
+REMARK   1 HAND-WRITTEN TEST TRAJECTORY
+CRYST1   25.000   25.000   25.000  90.00  90.00  90.00 P 1          1 
+HETATM    1  C1  XXX A   1       0.250   0.750   0.000  1.00  0.00           C
+HETATM    2  C2  XXX A   1       0.250   1.250   0.000  1.00  0.00           C
+HETATM    3  C1  XXX A   2       2.250   2.750   0.000  1.00  0.00           C
+HETATM    4  C2  XXX A   2       2.750   2.750   0.000  1.00  0.00           C
+HETATM    5  C1  XXX A   3       0.750   1.750   0.000  1.00  0.00           C
+HETATM    6  C2  XXX A   3       1.250   1.750   0.000  1.00  0.00           C
+HETATM    7  C1  XXX A   4       1.250   2.250   0.000  1.00  0.00           C
+HETATM    8  C2  XXX A   4       1.250   2.750   0.000  1.00  0.00           C
+HETATM    9  C1  XXX A   5       2.250   0.250   0.000  1.00  0.00           C
+HETATM   10  C2  XXX A   5       2.250   0.750   0.000  1.00  0.00           C
+ENDMDL
+CRYST1   25.000   25.000   25.000  90.00  90.00  90.00 P 1          1 
+HETATM    1  C1  XXX A   1       0.250   0.750   0.000  1.00  0.00           C
+HETATM    2  C2  XXX A   1       0.250   1.250   0.000  1.00  0.00           C
+HETATM    3  C1  XXX A   2       2.250   2.750   0.000  1.00  0.00           C
+HETATM    4  C2  XXX A   2       2.750   2.750   0.000  1.00  0.00           C
+HETATM    5  C1  XXX A   3       1.250   1.750   0.000  1.00  0.00           C
+HETATM    6  C2  XXX A   3       0.750   1.750   0.000  1.00  0.00           C
+HETATM    7  C1  XXX A   4       1.250   2.250   0.000  1.00  0.00           C
+HETATM    8  C2  XXX A   4       1.250   2.750   0.000  1.00  0.00           C
+HETATM    9  C1  XXX A   5       2.250   0.250   0.000  1.00  0.00           C
+HETATM   10  C2  XXX A   5       2.250   0.750   0.000  1.00  0.00           C
+ENDMDL
+CRYST1   25.000   25.000   25.000  90.00  90.00  90.00 P 1          1 
+HETATM    1  C1  XXX A   1       0.250   0.750   0.000  1.00  0.00           C
+HETATM    2  C2  XXX A   1       0.250   1.250   0.000  1.00  0.00           C
+HETATM    3  C1  XXX A   2       2.250   2.750   0.000  1.00  0.00           C
+HETATM    4  C2  XXX A   2       2.750   2.750   0.000  1.00  0.00           C
+HETATM    5  C1  XXX A   3       0.750   1.750   0.000  1.00  0.00           C
+HETATM    6  C2  XXX A   3       1.250   1.750   0.000  1.00  0.00           C
+HETATM    7  C1  XXX A   4       1.250   2.250   0.000  1.00  0.00           C
+HETATM    8  C2  XXX A   4       1.250   2.750   0.000  1.00  0.00           C
+HETATM    9  C1  XXX A   5       2.250   0.250   0.000  1.00  0.00           C
+HETATM   10  C2  XXX A   5       2.250   0.750   0.000  1.00  0.00           C
+ENDMDL
+CRYST1   25.000   25.000   25.000  90.00  90.00  90.00 P 1          1 
+HETATM    1  C1  XXX A   1       0.250   0.750   0.000  1.00  0.00           C
+HETATM    2  C2  XXX A   1       0.250   1.250   0.000  1.00  0.00           C
+HETATM    3  C1  XXX A   2       2.250   2.750   0.000  1.00  0.00           C
+HETATM    4  C2  XXX A   2       2.750   2.750   0.000  1.00  0.00           C
+HETATM    5  C1  XXX A   3       0.750   1.750   0.000  1.00  0.00           C
+HETATM    6  C2  XXX A   3       1.250   1.750   0.000  1.00  0.00           C
+HETATM    7  C1  XXX A   4       0.750   2.250   0.000  1.00  0.00           C
+HETATM    8  C2  XXX A   4       1.250   2.250   0.000  1.00  0.00           C
+HETATM    9  C1  XXX A   5       2.250   0.250   0.000  1.00  0.00           C
+HETATM   10  C2  XXX A   5       2.250   0.750   0.000  1.00  0.00           C
+ENDMDL
+CRYST1   25.000   25.000   25.000  90.00  90.00  90.00 P 1          1 
+HETATM    1  C1  XXX A   1       0.250   0.750   0.000  1.00  0.00           C
+HETATM    2  C2  XXX A   1       0.250   1.250   0.000  1.00  0.00           C
+HETATM    3  C1  XXX A   2       2.250   2.750   0.000  1.00  0.00           C
+HETATM    4  C2  XXX A   2       2.750   2.750   0.000  1.00  0.00           C
+HETATM    5  C1  XXX A   3       0.750   1.750   0.000  1.00  0.00           C
+HETATM    6  C2  XXX A   3       1.250   1.750   0.000  1.00  0.00           C
+HETATM    7  C1  XXX A   4       0.750   2.250   0.000  1.00  0.00           C
+HETATM    8  C2  XXX A   4       1.250   2.250   0.000  1.00  0.00           C
+HETATM    9  C1  XXX A   5       0.750   1.250   0.000  1.00  0.00           C
+HETATM   10  C2  XXX A   5       0.750   0.750   0.000  1.00  0.00           C
+ENDMDL
+END


### PR DESCRIPTION
This will include tests for the main contact-related objects. And I'm moving over to `pytest`!

- [x] Tests for `ContactMap`
- [x] Tests for `ContactFrequency`
- [x] Tests for `ContactDifference`
- [x] Full coverage of `ContactObject`
- [x] Tests for `ContactCount`
- [x] Move min dist and atom neighbors code to another file
- [x] Tests for `residue_neighborhood`