### PR TITLE
Release 0.1.5

### DIFF
--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: contact_map
   # add ".dev0" for unreleased versions
-  version: "0.1.5.dev0"
+  version: "0.1.5"
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
 VERSION = "0.1.5"
-IS_RELEASE = False
+IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases
 PRE_TYPE = ""  # a, b, or rc (although we rarely release such versions)


### PR DESCRIPTION
The 0.1.x release cycle is primarily for testing automated release process we're putting in place. The first release for public use will be 0.2.0. This is a test release for 0.2.0.

This release fixes a bug in the deployment process from the previous release. See the [release notes for 0.1.3](https://github.com/dwhswenson/contact_map/releases/tag/v0.1.3) for more information about new features and other improvements.