### PR TITLE
Release 0.2.0

### DIFF
--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: contact_map
   # add ".dev0" for unreleased versions
-  version: "0.1.5"
+  version: "0.2.0"
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 ####################### USER SETUP AREA #################################
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
-VERSION = "0.1.5"
+VERSION = "0.2.0"
 IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases


### PR DESCRIPTION
First public-ready release of `contact_map`. This marks the version that will be used for the E-CAM module.

Future release notes will details new features and other improvements. API breaks will also be included in the release notes. Following [semver](http://semver.org), during the `0.x.y` cycle, API breaks are allowed (although we will try to only make them between `0.x.y` and `0.(x+1).0`). After 1.0, API breaks will require a change of the major version number.

Some of the details in the progress to date can be seen in the release notes from the experimental releases of the `0.1.x` sequence. More complete documentation is available at https://contact-map.readthedocs.io/