### PR TITLE
Drop Python 3.4 support [travis]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - '3.6'
   - '2.7'
-  - '3.4'
   - '3.5'
 
 branches:
@@ -27,8 +26,6 @@ env:
 
 matrix:
   exclude:
-    - env: MDTRAJ="dev"
-      python: "3.4"
     - env: MDTRAJ="dev"
       python: "3.5"
 


### PR DESCRIPTION
`pandas` no longer has wheels for Py-3.4, so we can't pip-install. We require pandas for serialization/deserialization, which is an essential (not optional) feature. Therefore we can no longer support 3.4. Also, MDTraj doesn't test against 3.4 anyway.