### PR TITLE
fixed pandas future warn about as_matrix

### DIFF
--- a/contact_map/tests/test_contact_count.py
+++ b/contact_map/tests/test_contact_count.py
@@ -71,9 +71,9 @@ class TestContactCount(object):
         assert isinstance(atom_df, pd.SparseDataFrame)
         assert isinstance(residue_df, pd.SparseDataFrame)
 
-        assert_array_equal(atom_df.to_dense().as_matrix(),
+        assert_array_equal(atom_df.to_dense().values,
                            zero_to_nan(self.atom_matrix))
-        assert_array_equal(residue_df.to_dense().as_matrix(),
+        assert_array_equal(residue_df.to_dense().values,
                            zero_to_nan(self.residue_matrix))
 
     @pytest.mark.parametrize("obj_type", ['atom', 'res'])


### PR DESCRIPTION
Since pandas version `0.23` a `FutureWarning` popped up:
```
contact_map/tests/test_contact_count.py::TestContactCount::()::test_df
  /home/sander/github_files/contact_map/contact_map/tests/test_contact_count.py:74: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
    assert_array_equal(atom_df.to_dense().as_matrix(),
  /home/sander/github_files/contact_map/contact_map/tests/test_contact_count.py:76: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
    assert_array_equal(residue_df.to_dense().as_matrix(),
```
This fixes that warning in the way proposed by the warning 