### PR TITLE
Handle dask TimeoutError exception in tests

### DIFF
--- a/contact_map/tests/test_dask_runner.py
+++ b/contact_map/tests/test_dask_runner.py
@@ -14,6 +14,9 @@ def dask_setup_test_cluster(distributed, n_workers=4, n_attempts=3):
     for _ in range(n_attempts):
         try:
             cluster = distributed.LocalCluster(n_workers=n_workers)
+        except AttributeError:
+            # should never get here, because should have already skipped
+            pytest.skip("dask.distributed not installed")
         except distributed.TimeoutError:
             continue
         else:
@@ -29,7 +32,7 @@ class TestDaskContactFrequency(object):
         distributed = pytest.importorskip('dask.distributed')
         # Explicitly set only 4 workers on Travis instead of 31
         # Fix copied from https://github.com/spencerahill/aospy/pull/220/files
-        cluster = dask_setup_test_cluster(distributed)
+        cluster = dask_setup_test_cluster(distributed, n_workers=4)
         client = distributed.Client(cluster)
         filename = find_testfile("trajectory.pdb")
 


### PR DESCRIPTION
We're still occasionally getting an error when dask fails to start up a cluster (not as often as before #40, but still happens sometimes).

This PR changes the `distributed.LocalCluster` startup so that we can retry a fixed number of times. For now, I'm doing 3 retries. In addition, if all the retries fail, this gives a skip instead of a fail.

If all the retries fail in both the Travis jobs where we try dask, then we'll see a drop in coverage, but I think this will also mean that our coverage will be more stable.

Importantly, the skip only happens if the setup fails. And if the setup is failing consistently (e.g., due to an [unlikely!] API change in dask), I hope we'll notice the drop in coverage.