### PR TITLE
Fix docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,12 +2,12 @@ name: test
 channels:
     - conda-forge
 dependencies:
-    - python
+    - python=3.7
     - mdtraj=1.9.2
     - numpy=1.16.2
     - scipy=1.2.1
     - pandas=0.24.2
-    - packaging
-    - nbsphinx
-    - pandoc
-    - jupyter
+    - packaging=19.0
+    - nbsphinx=0.4.2
+    - pandoc=2.7.1
+    - jupyter=1.0.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,6 @@ dependencies:
     - scipy=1.2.1
     - pandas=0.24.2
     - packaging=19.0
-    - nbsphinx=0.4.2
-    - pandoc=2.7.1
-    - jupyter=1.0.0
+    - nbsphinx
+    - pandoc
+    - jupyter

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,5 @@
 name: test
 channels:
-    - defaults
     - conda-forge
 dependencies:
     - python

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,10 +3,10 @@ channels:
     - conda-forge
 dependencies:
     - python
-    - mdtraj
-    - numpy
-    - scipy
-    - pandas
+    - mdtraj=1.9.2
+    - numpy=1.16.2
+    - scipy=1.2.1
+    - pandas=0.24.2
     - packaging
     - nbsphinx
     - pandoc

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,5 @@
 name: test
 channels:
-    - omnia
     - defaults
     - conda-forge
 dependencies:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+packaging
+nbsphinx
+pandoc
+jupyter

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,0 +1,2 @@
+cython
+numpy

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,14 +1,13 @@
 version: 2
-#conda:
-    #file: docs/environment.yml
 
 python:
     install:
-      #- requirements: requirements.txt
-      #- requirements: docs/requirements.txt
+      - requirements: docs/rtd_requirements.txt
+      - requirements: requirements.txt
+      - requirements: docs/requirements.txt
       - method: pip
         path: .
     system_packages: false
 
-conda:
-    environment: docs/environment.yml
+#conda:
+    #environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,12 +2,12 @@ version: 2
 
 python:
     install:
-      - requirements: docs/rtd_requirements.txt
-      - requirements: requirements.txt
-      - requirements: docs/requirements.txt
+      #- requirements: docs/rtd_requirements.txt
+      #- requirements: requirements.txt
+      #- requirements: docs/requirements.txt
       - method: pip
         path: .
     system_packages: false
 
-#conda:
-    #environment: docs/environment.yml
+conda:
+    environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+conda:
+    environment: docs/environment.yml
+
 python:
     install:
       #- requirements: docs/rtd_requirements.txt
@@ -9,5 +12,3 @@ python:
         path: .
     system_packages: false
 
-conda:
-    environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,8 +4,11 @@ version: 2
 
 python:
     install:
-      - requirements: requirements.txt
-      - requirements: docs/requirements.txt
+      #- requirements: requirements.txt
+      #- requirements: docs/requirements.txt
       - method: pip
         path: .
     system_packages: false
+
+conda:
+    environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,4 +8,4 @@ python:
       - requirements: docs/requirements.txt
       - method: pip
         path: .
-    system_packages: true
+    system_packages: false

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,9 @@ python:
       #- requirements: docs/rtd_requirements.txt
       #- requirements: requirements.txt
       #- requirements: docs/requirements.txt
-      - method: pip
+      - method: setuptools
         path: .
-    system_packages: false
+      #- method: pip
+        #path: .
+    #system_packages: false
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,11 @@
-conda:
-    file: docs/environment.yml
+version: 2
+#conda:
+    #file: docs/environment.yml
 
 python:
-    setup_py_install: true
+    install:
+      - requirements: requirements.txt
+      - requirements: docs/requirements.txt
+      - method: pip
+        path: .
+    system_packages: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 future
+cython
 numpy
 scipy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 future
-cython
 numpy
 scipy
 pandas


### PR DESCRIPTION
Resolves #49.

Had to pin almost everything (I couldn't get a pip install of MDTraj working on RTD). The things specific to docs (like the `nbsphinx` extension) are not pinned, but all the scientific things (MDTraj, numpy, etc) are pinned in the RTD environment.

Note that these pins only affect the doc building environment, not the testing environment.

I also left things in place to again attempt a pip-based install at a later date.

Only affects things specific to how RTD builds the docs.