### PR TITLE
Fix coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - '3.6'
   - '3.7'
 
+notifications:
+  webhooks: https://coveralls.io/webhook
+
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   - py.test -vv --cov=contact_map --cov-report xml:cov.xml
 
 after_success:
+  - export COVERALLS_PARALLEL=true
   - coveralls
   - python-codacy-coverage -r cov.xml
 


### PR DESCRIPTION
Coveralls is reporting each build separately, instead of combining them. There are multiple instances of each file when looking at coverage data. This is trying to fix that.