### PR TITLE
pin pandas<1.0

### DIFF
--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - mdtraj
     - numpy
     - scipy
-    - pandas
+    - pandas<1.0
 
 test:
   requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future
 numpy
 scipy
-pandas
+pandas<1.0
 mdtraj

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     numpy
     mdtraj
     scipy
-    pandas
+    pandas<1.0
 packages = find:
 
 [bdist_wheel]


### PR DESCRIPTION
There's a problem with sparse matrices in pandas 1.0. See #69 for details. Once that gets fixed, we'll unpin.