### PR TITLE
Drop Py27 and Win32; add Py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ version: ~> 1.0
 
 language: python
 python:
+  - '3.8'
   - '3.7'
-  - '2.7'
   - '3.6'
 
 notifications:
@@ -17,7 +17,7 @@ branches:
 
 env:
   global:
-    - CANONICAL_PYTHON="3.7"
+    - CANONICAL_PYTHON="3.8"
     - CANONICAL_MDTRAJ="release"
     - CODECLIMATE=""
     - TWINE_USERNAME="dwhswenson"
@@ -33,6 +33,8 @@ jobs:
   exclude:
     - env: MDTRAJ="dev"
       python: "3.6"
+    - env: MDTRAJ="dev"
+      python: "3.7"
 
 before_install:
   - echo "before install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,11 @@ env:
     - secure: "g+pFYJ62KN/gfnzrzQlfRTyDwvIpwQp4aQvwB4GVrWUISoOx3X8IlK5+S26Wb/BK4cCIGAKWs+dVgCr1Ag0v4TBhmi4CBlkZXQTNv3TcbGwyhmXYbO7kf03lpapsxKu5JkFlZqe0fniwocut6d2BiAuRQjvJ1B+xhEkl3t/ARarg0G/e+1geNyCopULD3tzcUDV4BFUw6cjfm4Sqn008m+7F8vgNOG+HitPtjggmZfFgoZVvS3nnZbFxGq99Uit8PST8Rdus3PJFNJlguf4XTpsdYZeW2CjFfd9P/v8hvfM3ATSCJ8Mzh8PuWJFP48Be6IvJAn6qhgJW7jSDK6bcCahS0BXBr0EqT9maC3jNXTQiem8WT990mUbK9tpbj6a9HPaD/E1XfmfC2he/EIRt/p14hNPB8rMIR0NRcA0Hy4mTn6AsfUgzwFSRZqjicvLlgwFokn32usZAkcNsW7KQE2+YVnUq6VYG/wpCd5w3x/4sws/HWTTR0Kg98pqt31s3oI0KCktFCuz2Ipxj4sNYJ8ExwqJ3v4zr0505YpYLnJCqy02nbwBcmHv8GrodmlGn2Y5Wid3BZrn5VYQIZVWVSVosfT7B5VpcFVdXRSY5VoKE8mTU7c98HmvASOygG6TZyQBkwXWsEBDoKMssK6QuCjaJpoQt1ZkvpMVsFzzoJkY="
   matrix:
     - MDTRAJ="release"
-    - MDTRAJ="dev"
 
 jobs:
-  exclude:
+  include:
     - env: MDTRAJ="dev"
-      python: "3.6"
-    - env: MDTRAJ="dev"
-      python: "3.7"
+      python: "3.8"
 
 before_install:
   - echo "before install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,16 @@ env:
     - secure: "onsUSX6Yxt0HJApAsyUr5iFQW1ZngBiMxKmdiI5aN0TqnVSQ6819xx0YIxBjgburG/pFoW1F8bh8KYITV6TKK7RpcwdOspqpeO0X6L0DdBvNWQdl99QtJZcuMS3nPBiJ4guwrJCkQa/iKgZ7k27YukTw5pgKKDgC2d10P5SQiVFHNkX8lo4FzZIBnpA93Nq9G+j2pi14PpGtxaXhktqLOSvLvy/7BIWfzy69HDGjKZ38SMF4RFRnHiBI0G2uON6N5AuLovBWpRrmPmCTiX3p2lgxss8oUSKsA9OlikAoGlLyOjzMU2Fu3JqgoXPSyjDzkqO/Bavd1S03RYUeB5cRM9kBoORjCYl2dBCAmh7U41ZigvivYC2UZ/2p300f9YmolZ4vcj9tz4THXfF5/ZgIoARFIVk3fIQOHJCnXwa3gDcf0AEmsYOUOSKJKyYxruQhyjb2reFxUyA6bqtelV82qpMT53fSZ1/ZJjA+yJJgbeB9qkrMjvUf9AjlY8faqXyIafJsogFuvg1rg+FddMlc56zUWCEdc/pgbTesQuF8GCqje++7eaN68KiWBPwjDSX6cuNkeg86xx1E4VsRcXH6rQ9JXCsGs/HN4JRZ5J+ZH4YOHaUc5pTG82mTEZHGCjAN+BuhGfSFcgSoGO6oOHRGVjw47emOLvNpjS05B/zu/4c="
     # AUTORELEASE_TOKEN
     - secure: "g+pFYJ62KN/gfnzrzQlfRTyDwvIpwQp4aQvwB4GVrWUISoOx3X8IlK5+S26Wb/BK4cCIGAKWs+dVgCr1Ag0v4TBhmi4CBlkZXQTNv3TcbGwyhmXYbO7kf03lpapsxKu5JkFlZqe0fniwocut6d2BiAuRQjvJ1B+xhEkl3t/ARarg0G/e+1geNyCopULD3tzcUDV4BFUw6cjfm4Sqn008m+7F8vgNOG+HitPtjggmZfFgoZVvS3nnZbFxGq99Uit8PST8Rdus3PJFNJlguf4XTpsdYZeW2CjFfd9P/v8hvfM3ATSCJ8Mzh8PuWJFP48Be6IvJAn6qhgJW7jSDK6bcCahS0BXBr0EqT9maC3jNXTQiem8WT990mUbK9tpbj6a9HPaD/E1XfmfC2he/EIRt/p14hNPB8rMIR0NRcA0Hy4mTn6AsfUgzwFSRZqjicvLlgwFokn32usZAkcNsW7KQE2+YVnUq6VYG/wpCd5w3x/4sws/HWTTR0Kg98pqt31s3oI0KCktFCuz2Ipxj4sNYJ8ExwqJ3v4zr0505YpYLnJCqy02nbwBcmHv8GrodmlGn2Y5Wid3BZrn5VYQIZVWVSVosfT7B5VpcFVdXRSY5VoKE8mTU7c98HmvASOygG6TZyQBkwXWsEBDoKMssK6QuCjaJpoQt1ZkvpMVsFzzoJkY="
-  matrix:
+  jobs:
     - MDTRAJ="release"
+    - MDTRAJ="dev"
 
 jobs:
-  include:
+  exclude:
     - env: MDTRAJ="dev"
-      python: "3.8"
+      python: "3.6"
+    - env: MDTRAJ="dev"
+      python: "3.7"
 
 before_install:
   - echo "before install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build: false
 
 install:
   # install python
-  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\condabin;%PATH%
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\bin;%PATH\\Library\\bin;%PATH%
   - conda config --add channels conda-forge
   #- conda install -yq conda=4.5 conda-build=3.10
   - conda install -yq conda conda-build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda38-x64"
-      CONDA_PY: "38" 
-      ARCH: '64'
+    #- PYTHON: "C:\\Miniconda38-x64"
+      #CONDA_PY: "38" 
+      #ARCH: '64'
     - PYTHON: "C:\\Miniconda37-x64"
       CONDA_PY: "37"
       ARCH: '64'
@@ -29,7 +29,6 @@ build: false
 install:
   # install python
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\bin;%PATH\\Library\\bin;%PATH%
-  - call %PYTHON%\Scripts\activate.bat
   - conda config --add channels conda-forge
   #- conda install -yq conda=4.5 conda-build=3.10
   - conda install -yq conda conda-build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ build: false
 install:
   # install python
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\bin;%PATH\\Library\\bin;%PATH%
+  - call %PYTHON%\Scripts\activate.bat
   - conda config --add channels conda-forge
   #- conda install -yq conda=4.5 conda-build=3.10
   - conda install -yq conda conda-build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,8 @@ install:
   # install python
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - conda config --add channels conda-forge
-  - conda install -yq conda=4.5 conda-build=3.10
+  #- conda install -yq conda=4.5 conda-build=3.10
+  - conda install -yq conda conda-build
 
 test_script:
   #- "%CMD_IN_ENV% activate base"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,17 +14,14 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda"
-      CONDA_PY: "27"
-      ARCH: '32'
-    - PYTHON: "C:\\Miniconda-x64"
-      CONDA_PY: "27"
+    - PYTHON: "C:\\Miniconda38-x64"
+      CONDA_PY: "38" 
       ARCH: '64'
-    - PYTHON: "C:\\Miniconda36"
-      CONDA_PY: "36" # No MDTraj for py37/Win32
-      ARCH: '32'
     - PYTHON: "C:\\Miniconda37-x64"
       CONDA_PY: "37"
+      ARCH: '64'
+    - PYTHON: "C:\\Miniconda36-x64"
+      CONDA_PY: "36" 
       ARCH: '64'
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,10 @@ environment:
 build: false
 
 install:
-  # install python
-  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\bin;%PATH\\Library\\bin;%PATH%
+  # set up conda Python
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - conda config --add channels conda-forge
-  #- conda install -yq conda=4.5 conda-build=3.10
+  # note: it may become necessary to pin versions of conda/conda-build
   - conda install -yq conda conda-build
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build: false
 
 install:
   # install python
-  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON\\condabin;%PATH%
   - conda config --add channels conda-forge
   #- conda install -yq conda=4.5 conda-build=3.10
   - conda install -yq conda conda-build


### PR DESCRIPTION
Currently our Travis script has a Py27/MDTraj dev test job. However, MDTraj has made changes that are incompatible with Py27. We'd already discussed dropping Py27 and Win32 from tests (https://github.com/dwhswenson/contact_map/pull/69#issuecomment-585827472), so I'm doing it now.

While I'm at it, I'm including Py38 in our test matrix (overdue!). Note that the next release will be the last one to guarantee support Python 3.6 (by NEP29 we could already drop 3.6, but I'm going to take a slightly more conservative approach.)

