### PR TITLE
Coveralls cleanup

### DIFF
--- a/ci/pip-install/testing_requirements.txt
+++ b/ci/pip-install/testing_requirements.txt
@@ -1,5 +1,5 @@
 pytest
 pytest-cov
-python-coveralls
+coveralls
 codacy-coverage
 autorelease

--- a/contact_map/contact_count.py
+++ b/contact_map/contact_count.py
@@ -130,7 +130,7 @@ class ContactCount(object):
         index = list(range(self.n_x))
         columns = list(range(self.n_y))
 
-        if _PD_VERSION < (0, 25):  # py27 only
+        if _PD_VERSION < (0, 25):  # py27 only  -no-cov-
             mtx = mtx.tocoo()
             return pd.SparseDataFrame(mtx, index=index, columns=columns)
 

--- a/contact_map/contact_count.py
+++ b/contact_map/contact_count.py
@@ -31,7 +31,7 @@ def _colorbar(with_colorbar, cmap_f, norm, min_val, ax=None):
 # TODO: remove following: this is a monkeypatch for a bug in pandas
 # see: https://github.com/pandas-dev/pandas/issues/29814
 from pandas._libs.sparse import BlockIndex, IntIndex, SparseIndex
-def _patch_from_spmatrix(cls, data):
+def _patch_from_spmatrix(cls, data):  # -no-cov-
     length, ncol = data.shape
 
     if ncol != 1:

--- a/contact_map/py_2_3.py
+++ b/contact_map/py_2_3.py
@@ -2,7 +2,7 @@ import inspect
 
 try:
     getargspec = inspect.getfullargspec
-except AttributeError:
+except AttributeError:  # -no-cov-
     getargspec = inspect.getargspec
 
 def inspect_method_arguments(method, no_self=True):


### PR DESCRIPTION
Coveralls has been (silently) failing since coverage 5 was released (late 2019). This brings coveralls back to our PRs (by switching from the defunct `python-coveralls` to `coveralls`) and excludes from coverage a few things that are no longer expected to be covered by tests (stuff for Python 2 and pandas < 1.1).

The things that are currently excluded should, at some point, be removed. But I see no reason to rush to break things that work for some users -- besides, we haven't officially updated to require these more recent versions; just we don't guarantee that the old versions will continue to work.