### PR TITLE
Remove `ContactMap` (allowing rename `ContactFrequency` => `ContactMap`)

### DIFF
--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: contact_map
   # add ".dev0" for unreleased versions
-  version: "0.6.1.dev0"
+  version: "0.7.0.dev0"
 
 source:
   path: ../../

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -637,9 +637,15 @@ class ContactFrequency(ContactObject):
     """
     # Default for use_atom_slice, None tries to be smart
     _class_use_atom_slice = None
+    _pending_dep_msg = (
+        "ContactFrequency will be renamed to ContactMap in version 0.8. "
+        + "Invoking it as ContactFrequency will be deprecated in 0.8. For "
+        + "more, see https://github.com/dwhswenson/contact_map/issues/82"
+    )
 
     def __init__(self, trajectory, query=None, haystack=None, cutoff=0.45,
                  n_neighbors_ignored=2, frames=None):
+        warnings.warn(self._pending_dep_msg, PendingDeprecationWarning)
         if frames is None:
             frames = range(len(trajectory))
         self.frames = frames
@@ -654,12 +660,23 @@ class ContactFrequency(ContactObject):
     def from_contacts(cls, atom_contacts, residue_contacts, n_frames,
                       topology, query=None, haystack=None, cutoff=0.45,
                       n_neighbors_ignored=2, indexer=None):
+        warnings.warn(cls._pending_dep_msg, PendingDeprecationWarning)
         obj = super(ContactFrequency, cls).from_contacts(
             atom_contacts, residue_contacts, topology, query, haystack,
             cutoff, n_neighbors_ignored, indexer
         )
         obj._n_frames = n_frames
         return obj
+
+    @classmethod
+    def from_dict(cls, dct):
+        warnings.warn(cls._pending_dep_msg, PendingDeprecationWarning)
+        return super(ContactFrequency, cls).from_dict(dct)
+
+    @classmethod
+    def from_file(cls, filename):
+        warnings.warn(cls._pending_dep_msg, PendingDeprecationWarning)
+        return super(ContactFrequency, cls).from_file(filename)
 
     def __hash__(self):
         return hash((super(ContactFrequency, self).__hash__(),

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -602,7 +602,7 @@ class ContactObject(object):
 
 CONTACT_MAP_ERROR = (
     "The ContactMap class has been removed. Please use ContactFrequency."
-   + " For more, see: https://github.com/dwhswenson/contact_map/issues/82"
+    " For more, see: https://github.com/dwhswenson/contact_map/issues/82"
 )
 def ContactMap(*args, **kwargs):  # -no-cov-
     raise RuntimeError(CONTACT_MAP_ERROR)
@@ -639,8 +639,8 @@ class ContactFrequency(ContactObject):
     _class_use_atom_slice = None
     _pending_dep_msg = (
         "ContactFrequency will be renamed to ContactMap in version 0.8. "
-        + "Invoking it as ContactFrequency will be deprecated in 0.8. For "
-        + "more, see https://github.com/dwhswenson/contact_map/issues/82"
+        "Invoking it as ContactFrequency will be deprecated in 0.8. For "
+        "more, see https://github.com/dwhswenson/contact_map/issues/82"
     )
 
     def __init__(self, trajectory, query=None, haystack=None, cutoff=0.45,

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -693,61 +693,12 @@ class ContactObject(object):
                             n_res, n_res)
 
 
-class ContactMap(ContactObject):
-    """
-    Contact map (atomic and residue) for a single frame.
-
-    .. deprecated:: 0.6.0
-        ``ContactMap`` will be removed in Contact Map Explorer 0.7.0 because
-        it is redundant with ``ContactFrequency``. For more, see
-        https://github.com/dwhswenson/contact_map/issues/82.
-
-    """
-    # Default for use_atom_slice, None tries to be smart
-    _class_use_atom_slice = None
-
-    _deprecation_message=(
-        "The ContactMap class will be removed in Contact Map Explorer 0.7. "
-        + "Use ContactFrequency instead. For more, see: "
-        + "https://github.com/dwhswenson/contact_map/issues/82."
-    )
-
-    def __init__(self, frame, query=None, haystack=None, cutoff=0.45,
-                 n_neighbors_ignored=2):
-        warnings.warn(self._deprecation_message, FutureWarning)
-        self._frame = frame  # TODO: remove this?
-        super(ContactMap, self).__init__(frame.topology, query, haystack,
-                                         cutoff, n_neighbors_ignored)
-
-        contact_maps = self.contact_map(frame, 0,
-                                        self.residue_query_atom_idxs,
-                                        self.residue_ignore_atom_idxs)
-        (atom_contacts, self._residue_contacts) = contact_maps
-        self._atom_contacts = self.convert_atom_contacts(atom_contacts)
-
-    @classmethod
-    def from_dict(cls, dct):
-        warnings.warn(cls._deprecation_message, FutureWarning)
-        return super(ContactMap, cls).from_dict(dct)
-
-    # don't need to add deprecation in from_json because it uses from_dict
-
-    @classmethod
-    def from_file(cls, filename):
-        warnings.warn(cls._deprecation_message, FutureWarning)
-        return super(ContactMap, cls).from_file(filename)
-
-
-    def __hash__(self):
-        return hash((super(ContactMap, self).__hash__(),
-                     tuple(self._atom_contacts.items()),
-                     tuple(self._residue_contacts.items())))
-
-    def __eq__(self, other):
-        is_equal = (super(ContactMap, self).__eq__(other)
-                    and self._atom_contacts == other._atom_contacts
-                    and self._residue_contacts == other._residue_contacts)
-        return is_equal
+CONTACT_MAP_ERROR = (
+    "The ContactMap class has been removed. Please use ContactFrequency."
+   + " For more, see: https://github.com/dwhswenson/contact_map/issues/82"
+)
+def ContactMap(*args, **kwargs):  # -no-cov-
+    raise RuntimeError(CONTACT_MAP_ERROR)
 
 
 class ContactFrequency(ContactObject):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = contact_map
-version = 0.6.1.dev0
+version = 0.7.0.dev0
 description = Contact maps based on MDTraj
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This is the next step in #82. Removes `ContactMap` and adds `PendingDeprecationWarning` on `ContactFrequency`.

This also bumps the version to 0.7.0.dev0 (which should have been done as soon as we broke the API in #87; changed API means we're developing on the next 0.x).