### PR TITLE
Enable binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,9 @@ dependencies:
   - python
   - pip
   - matplotlib
+  - nglview
+  - dask
+  - distributed
   - pip:
     - tables
     - .

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - matplotlib
   - pip:
     - tables
+    - .

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,5 @@ dependencies:
   - python
   - pip
   - matplotlib
+  - pip:
+    - tables

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - pip
+  - matplotlib

--- a/postBuild
+++ b/postBuild
@@ -7,3 +7,4 @@ cd examples
 mkdir $figshare_ID
 curl -Lk -o ${figshare_ID}.zip https://ndownloader.figshare.com/articles/5550217?private_link=453b1b215cf2f9270769
 unzip -d $figshare_ID ${figshare_ID}.zip
+rm $figshare_ID.zip

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+figshare_ID=5550217
+
+# Dowload the extra example files
+cd examples
+mkdir $figshare_ID
+curl -Lk -o ${figshare_ID}.zip https://ndownloader.figshare.com/articles/5550217?private_link=453b1b215cf2f9270769
+unzip -d $figshare_ID ${figshare_ID}.zip


### PR DESCRIPTION
This will try to setup the right files for binder to be able to run our examples.

This will mainly use:
- `environment.yml` to build the `example` dependencies
- Maybe use a `postBuild` to pull in the example data.

Another PR will actually add the binder links to out repo.

current binder link for this branch:
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sroet/contact_map/try_binder?filepath=%2Fexamples)

Working examples (will update as I go):

- [X] Comparing different data structures
- [X] concurrences 
- [X] contact_map 
- [x] contact_map_without_atom_slice
- [X] contact_trajectory
- [x] dask_contact_frequency