### PR TITLE
Add binder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f7f3cf53698e4655ac8895f13fa5dea6)](https://www.codacy.com/app/dwhswenson/contact_map?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=dwhswenson/contact_map&amp;utm_campaign=Badge_Grade)
 [![Maintainability](https://api.codeclimate.com/v1/badges/84768756d594176d8da6/maintainability)](https://codeclimate.com/github/dwhswenson/contact_map/maintainability)
-
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dwhswenson/contact_map/master)
 # Contact Map Explorer
 
 This package provides tools for analyzing and exploring contacts
@@ -37,6 +37,8 @@ It also facilitates visualization of the contact matrix, with colors
 representing the fraction of trajectory time that the contact was present.
 
 Full documentation is at http://contact-map.readthedocs.io/.
+
+Try it out online: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples) (Note: the performance of the online servers can vary widely.)
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,25 @@ extensions = [
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting'
 ]
+# Adding jinja passthrough for html
+# Taken from https://www.ericholscher.com/blog/2016/jul/25/integrating-jinja-rst-sphinx/
+html_context = {"release": release,
+                "version": version}
+def rstjinja(app, docname, source):
+    """
+    Render our pages as a jinja template for fancy templating goodness.
+    """
+    # Make sure we're outputting HTML
+    if app.builder.format != 'html':
+        return
+    src = source[0]
+    rendered = app.builder.templates.render_string(
+        src, app.config.html_context
+    )
+    source[0] = rendered
+
+def setup(app):
+    app.connect("source-read", rstjinja)
 
 # Napolean settings
 napoleon_google_docstring = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,3 +385,27 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+# Try autogenerating binder links, adapted from
+# https://github.com/spatialaudio/nbsphinx/blob/345f406e6f98d584fa493c788099e68b218f3a30/doc/conf.py#L54
+nbsphinx_prolog = r"""
+{% set docname = env.doc2path(env.docname, base='').replace("/nb", "") %}
+{% if "dev" in env.config.release %}
+{% set version = "master" %}
+{% else %}
+{% set version = "v"+env.config.version %}
+{% endif %}
+.. only:: html
+
+    .. role:: raw-html(raw)
+        :format: html
+
+    .. nbinfo::
+
+        This page was generated from `{{ docname }}`__.
+        Interactive online version:
+        :raw-html:`<a href="https://mybinder.org/v2/gh/dwhswenson/contact_map/{{ version }}?filepath={{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
+
+    __ https://github.com/dwhswenson/contact_map/blob/
+        {{ version  }}/{{ docname }}
+"""

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -6,15 +6,17 @@ notebooks have been rendered here for the web, but the originals are
 found in the ``examples/`` directory of the package, and you can run them
 yourself! 
 
-You can also try them out online directly from your browser: 
-.. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples
-
-(Note: the performance of the online servers can vary widely.)
-
 .. toctree::
     :maxdepth: 1
     :glob:
 
     nb/*
+
+You can also try them out online directly from your browser: 
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples
+
+(Note: the performance of the online servers can vary widely.)
+
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -16,7 +16,6 @@ yourself!
 You can also try them out online directly from your browser: |binder|_
 (Note: the performance of the online servers can vary widely.)
 
-|binder|_ binder link
 
 .. toctree::
     :maxdepth: 1

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,3 +1,10 @@
+
+{% if "dev" in release %}                                            
+{% set version = "master" %}                                                    
+{% else %}                                                                      
+{% set version = "v"+version %}                                      
+{% endif %}  
+
 Examples
 ========
 
@@ -9,6 +16,8 @@ yourself!
 You can also try them out online directly from your browser: |binder|_
 (Note: the performance of the online servers can vary widely.)
 
+|binder|_ binder link
+
 .. toctree::
     :maxdepth: 1
     :glob:
@@ -16,4 +25,4 @@ You can also try them out online directly from your browser: |binder|_
     nb/*
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
-.. _binder: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples
+.. _binder: https://mybinder.org/v2/gh/dwhswenson/contact_map/{{ version }}?filepath=%2Fexamples

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -4,7 +4,13 @@ Examples
 We have several examples to illustrate various features of the code. These
 notebooks have been rendered here for the web, but the originals are
 found in the ``examples/`` directory of the package, and you can run them
-yourself!
+yourself! 
+
+You can also try them out online directly from your browser: 
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples
+
+(Note: the performance of the online servers can vary widely.)
 
 .. toctree::
     :maxdepth: 1

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -6,17 +6,14 @@ notebooks have been rendered here for the web, but the originals are
 found in the ``examples/`` directory of the package, and you can run them
 yourself! 
 
+You can also try them out online directly from your browser: |binder|_
+(Note: the performance of the online servers can vary widely.)
+
 .. toctree::
     :maxdepth: 1
     :glob:
 
     nb/*
 
-You can also try them out online directly from your browser: 
-
-.. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples
-
-(Note: the performance of the online servers can vary widely.)
-
-
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+.. _binder: https://mybinder.org/v2/gh/dwhswenson/contact_map/master?filepath=%2Fexamples


### PR DESCRIPTION
after pr #92 
This PR adds the repective binder links to the 
- [X] `README.md`
- [x] examples page of the documentation
- [X] add a link to binder for every notebook
- [X] enable `jinja2` rendering for all `.rst` your docs

(@dwhswenson any place missing? for example I can add a link to each `ipynb` that would start binder for themself) 