### PR TITLE
Future proof ParameterFixer

### DIFF
--- a/contact_map/fix_parameters.py
+++ b/contact_map/fix_parameters.py
@@ -6,10 +6,12 @@ class ParameterFixer(object):
     def __init__(self,
                  allow_mismatched_atoms=False,
                  allow_mismatched_residues=False,
-                 override_topology=True):
+                 override_topology=True,
+                 set_mixing='intersection'):
         self.allow_mismatched_atoms = allow_mismatched_atoms
         self.allow_mismatched_residues = allow_mismatched_residues
         self.override_topology = override_topology
+        self.set_mixing = set_mixing
 
     def get_parameters(self, map0, map1):
         """Get the required parameters to initialise ContactDifference"""
@@ -26,7 +28,9 @@ class ParameterFixer(object):
 
         for fail in failed:
             if fail in {'query', 'haystack'}:
-                fixed = []
+                map0_set = set(getattr(map0, fail))
+                map1_set = set(getattr(map1, fail))
+                fixed = getattr(map0_set, self.set_mixing)(map1_set)
             elif fail in {'cutoff', 'n_neighbors_ignored'}:
                 # We just set them to None
                 fixed = None

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -736,7 +736,7 @@ class TestContactDifference(object):
         diff = ttraj - frame
         diff.residue_contacts.plot()
 
-    @pytest.mark.parametrize("attr", [('query',[0]), ('haystack',[0]),
+    @pytest.mark.parametrize("attr", [('query',[0]), ('haystack',[1]),
                                       ('cutoff', 0.07),
                                       ('n_neighbors_ignored',1)])
 
@@ -750,7 +750,7 @@ class TestContactDifference(object):
         diff = ttraj - frame
         # Make sure the attributes are dead
         if attr[0] in {'query','haystack'}:
-            assert getattr(diff, attr[0]) == []
+            assert getattr(diff, attr[0]) == attr[1]
         else:
             assert getattr(diff, attr[0]) is None
         # Make sure we can still do the maps


### PR DESCRIPTION
While working on #94 I discovered that ParameterFixer might be a bit to strict in the way we handle `query` and `haystack`

The new implementation allows a developer to choose the type of mixing they want for a mismatched `query` or `haystack`.
For `ContactDifference` it makes sense to do a `intersection` as we also do that with the map so we do that as the default.

I think this should future-proof the class just incase we ever want a way of fixing these attributes by for example making a `union` (some iteratively building of the map), or maybe a `difference` (making a `ContactFrequency` that does not include a certain other ContactMap) etc