### PR TITLE
Update Travis badge to .com instead of .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Documentation Status](https://readthedocs.org/projects/contact-map/badge/?version=latest)](http://contact-map.readthedocs.io/en/latest/?badge=latest)
-[![Linux Build Status](https://travis-ci.org/dwhswenson/contact_map.svg?branch=master)](https://travis-ci.org/dwhswenson/contact_map)
+[![Build Status](https://travis-ci.com/dwhswenson/contact_map.svg?branch=master)](https://travis-ci.com/dwhswenson/contact_map)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/em3fo96sjrg2vmcc/branch/master?svg=true)](https://ci.appveyor.com/project/dwhswenson/contact-map/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/dwhswenson/contact_map/badge.svg?branch=master)](https://coveralls.io/github/dwhswenson/contact_map?branch=master)
 [![PyPI](https://img.shields.io/pypi/v/contact-map.svg)](https://pypi.python.org/pypi/contact-map/)


### PR DESCRIPTION
The reason I thought #99 was not completed yet, was due to this badge still linking to .org. This fixes that