### PR TITLE
update GA

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,10 +34,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/setup-python@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-python: true
+          auto-update-conda: true
           python-version: ${{ matrix.CONDA_PY }}
       - name: "Install"
         env:


### PR DESCRIPTION
The CI in #101 was complaining about not getting the commit SHA and about not knowing `auto-update-python`

This is a cherry pick of https://github.com/dwhswenson/contact_map/pull/101/commits/2a2dc38ce57e776a51511a438df392e7274e49b5