### PR TITLE
Fix lines missing from test coverage

### DIFF
--- a/contact_map/contact_count.py
+++ b/contact_map/contact_count.py
@@ -204,7 +204,8 @@ class ContactCount(object):
 
         # Check the number of pixels of the figure
         self._check_number_of_pixels(fig)
-        self.plot_axes(ax=ax, cmap=cmap, vmin=vmin, vmax=vmax)
+        self.plot_axes(ax=ax, cmap=cmap, vmin=vmin, vmax=vmax,
+                       with_colorbar=with_colorbar)
 
         return (fig, ax)
 

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -600,15 +600,11 @@ class ContactObject(object):
 
     @property
     def atom_contacts(self):
-        n_atoms = self.topology.n_atoms
-        return ContactCount(self._atom_contacts, self.topology.atom,
-                            n_atoms, n_atoms)
+        raise NotImplementedError()
 
     @property
     def residue_contacts(self):
-        n_res = self.topology.n_residues
-        return ContactCount(self._residue_contacts, self.topology.residue,
-                            n_res, n_res)
+        raise NotImplementedError()
 
 
 CONTACT_MAP_ERROR = (


### PR DESCRIPTION
Our test suite currently fails to cover 5 lines. This PR should fix that.

* One line was not covered because the `with_colorbar` option wasn't passed from `ContactCount.plot` to `ContactCount.plot_axes` in #79. This PR adds that functionality back in.
* Four lines were not covered because the implementation at `ContactObject.atom_contacts` and `ContactObject.residue_contacts` are now overridden in all subclasses. It used to be that `ContactMap` used these, but `ContactMap` was removed in #88. This PR makes those explicitly abstract by raising `NotImplementedError`.