### PR TITLE
Update GA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Documentation Status](https://readthedocs.org/projects/contact-map/badge/?version=latest)](http://contact-map.readthedocs.io/en/latest/?badge=latest)
-![Unit tests](https://github.com/dwhswenson/contact_map/workflows/Unit%20tests/badge.svg)
+[![Unit tests](https://github.com/dwhswenson/contact_map/actions/workflows/unit-tests.yml/badge.svg?branch=master)](https://github.com/dwhswenson/contact_map/actions/workflows/unit-tests.yml)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/em3fo96sjrg2vmcc/branch/master?svg=true)](https://ci.appveyor.com/project/dwhswenson/contact-map/branch/master)
 [![codecov](https://codecov.io/gh/dwhswenson/contact_map/branch/master/graph/badge.svg?token=4so8QmiC5W)](https://codecov.io/gh/dwhswenson/contact_map)
 [![PyPI](https://img.shields.io/pypi/v/contact-map.svg)](https://pypi.python.org/pypi/contact-map/)


### PR DESCRIPTION
I noticed that the GA badge does not link to the actual action page, but just to the svg. This updates it to track the `master` branch and should be updated accordingly when #113 is done.