### PR TITLE
define forgotten ne

### DIFF
--- a/contact_map/contact_trajectory.py
+++ b/contact_map/contact_trajectory.py
@@ -104,6 +104,9 @@ class ContactTrajectory(ContactObject, abc.Sequence):
     def __eq__(self, other):
         return hash(self) == hash(other)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def from_contacts(cls, atom_contacts, residue_contacts, topology,
                       query=None, haystack=None, cutoff=0.45,


### PR DESCRIPTION
while working on #115 , a test started failing with:
```
_______________________________ TestMutableContactTrajectory.test_hash_eq _______________________________

self = <contact_map.tests.test_contact_trajectory.TestMutableContactTrajectory object at 0x7fca5ea18dc0>

    def test_hash_eq(self):
        cmap = MutableContactTrajectory(self.traj, cutoff=0.075,
                                        n_neighbors_ignored=0)
        assert hash(cmap) != hash(self.map)
>       assert cmap != self.map
E       assert <contact_map.contact_trajectory.MutableContactTrajectory object at 0x7fca5ed678b0> != <contact_map.contact_trajectory.MutableContactTrajectory object at 0x7fca5eaa5850>
E        +  where <contact_map.contact_trajectory.MutableContactTrajectory object at 0x7fca5eaa5850> = <contact_map.tests.test_contact_trajectory.TestMutableContactTrajectory object at 0x7fca5ea18dc0>.map

contact_map/tests/test_contact_trajectory.py:222: AssertionError
```

Which was due to the fact the `ContactTrajectory` did update `__eq__`, but not `__ne__`. This fixes that oversight