### PR TITLE
Remove genindex from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,8 +43,6 @@ representing the fraction of trajectory time that the contact was present.
 
 .. Add understanding_docs at some point
 
-* :ref:`genindex`
-
 Contact Map Explorer is an open source project, released under the GNU LGPL,
 version 2.1 or (at your option) any later version. Development takes place
 in public at https://github.com/dwhswenson/contact_map; your contributions


### PR DESCRIPTION
This removes the page at https://contact-map.readthedocs.io/en/latest/genindex.html from the docs. Prior to today, that page had been visited only once this year. It seems to me like it is more likely to confuse users than help them (it only indexes the API sections, and the search functionality/browsing the API docs should be easier to use than this index.)