### PR TITLE
Actually test for the Userwarning on custom cmaps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,11 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    #- PYTHON: "C:\\Miniconda38-x64"
-      #CONDA_PY: "38" 
-      #ARCH: '64'
+    - PYTHON: "C:\\Miniconda38-x64"
+      CONDA_PY: "38" 
+      ARCH: '64'
     - PYTHON: "C:\\Miniconda37-x64"
       CONDA_PY: "37"
-      ARCH: '64'
-    - PYTHON: "C:\\Miniconda36-x64"
-      CONDA_PY: "36" 
       ARCH: '64'
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda38-x64"
-      CONDA_PY: "38" 
-      ARCH: '64'
     - PYTHON: "C:\\Miniconda37-x64"
       CONDA_PY: "37"
       ARCH: '64'

--- a/contact_map/tests/test_plot_utils.py
+++ b/contact_map/tests/test_plot_utils.py
@@ -14,6 +14,7 @@ except ImportError:
 else:
     HAS_MATPLOTLIB = True
 
+
 @pytest.mark.parametrize("val", [0.5, 0.55, 0.6, 0.65, 0.7])
 @pytest.mark.parametrize("map_type", ["name", "cmap"])
 def test_ranged_colorbar_cmap(map_type, val):
@@ -33,9 +34,11 @@ def test_ranged_colorbar_cmap(map_type, val):
     assert_allclose(cb.cmap(cb.norm(val)), default_cmap(norm(val)),
                     atol=atol)
 
+
 @pytest.mark.parametrize("cmap", ['seismic', 'Blues', 'custom'])
 def test_is_cmap_diverging(cmap):
     custom = None
+
     if HAS_MATPLOTLIB:
         custom = LinearSegmentedColormap(
             'testCmap',
@@ -43,29 +46,29 @@ def test_is_cmap_diverging(cmap):
                 'red':   [[0.0,  0.0, 0.0],
                           [0.5,  1.0, 1.0],
                           [1.0,  1.0, 1.0]],
-                 'green': [[0.0,  0.0, 0.0],
-                           [0.25, 0.0, 0.0],
-                           [0.75, 1.0, 1.0],
-                           [1.0,  1.0, 1.0]],
-                 'blue':  [[0.0,  0.0, 0.0],
-                           [0.5,  0.0, 0.0],
-                           [1.0,  1.0, 1.0]]},
+                'green': [[0.0,  0.0, 0.0],
+                          [0.25, 0.0, 0.0],
+                          [0.75, 1.0, 1.0],
+                          [1.0,  1.0, 1.0]],
+                'blue':  [[0.0,  0.0, 0.0],
+                          [0.5,  0.0, 0.0],
+                          [1.0,  1.0, 1.0]]},
             N=256
         )
     elif cmap == 'custom':
         # no matplotlib; can't do custom
         pytest.skip()
 
-    cmap, expected = {
+    color_map, expected = {
         'seismic': ('seismic', True),
         'Blues': ('Blues', False),
         'custom': (custom, False),
     }[cmap]
     if cmap == 'custom':
-        with pytest.warns(UserWarning):
-            assert is_cmap_diverging(cmap) == expected
+        with pytest.warns(UserWarning, match="Unknown colormap"):
+            assert is_cmap_diverging(color_map) == expected
     else:
-        assert is_cmap_diverging(cmap) == expected
+        assert is_cmap_diverging(color_map) == expected
 
 
 class TestContactRange(object):


### PR DESCRIPTION
I was looking into the reason why a `UserWarning` surfaced from our test suite.
```
=========================================== warnings summary ============================================
contact_map/tests/test_plot_utils.py::test_is_cmap_diverging[custom]
  /home/sander/github_files/contact_map/contact_map/plot_utils.py:31: UserWarning: Unknown colormap: Treating as sequential.
    warnings.warn("Unknown colormap: Treating as sequential.")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

The reason was that the variable `cmap` was redefined before the line `if cmap == 'custom'` leading to the `if` statement never being true. 

This fixes that, makes sure we raise the correct warning and keeps the warning from showing up in the warning summary)
It also solves some whitespace complaints from my development environment.