### PR TITLE
swap from codecov bash uploader to their github action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -95,6 +95,5 @@ jobs:
         run: |
           python -c "import contact_map"
           py.test -vv --cov=contact_map --cov-report xml
-      - name: "Report coverage"
+      - uses: codecov/codecov-action@v2
         if: ${{ github.event != 'schedule' }}
-        run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
OPS just got hit by a [planned brownout of the bash uploader](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) of codecov to notify of the planned deprecation. This swaps the usage of the deprecated bash uploader for [v2 of their github action](https://github.com/marketplace/actions/codecov)