### PR TITLE
use new way of checking for no warnings

### DIFF
--- a/contact_map/tests/test_contact_count.py
+++ b/contact_map/tests/test_contact_count.py
@@ -62,10 +62,9 @@ class TestContactCount(object):
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason="Missing matplotlib")
     def test_pixel_warning(self):
         # This should not raise a warning (5*2>=10)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
             self.atom_contacts.plot(figsize=(5, 5), dpi=2)
-        # See if no warning was raised
-        assert len(record) == 0
 
         # Now raise the warning as 4*2 < 10
         with pytest.warns(RuntimeWarning) as record:


### PR DESCRIPTION
our test suite started warning:
```
contact_map/tests/test_contact_count.py::TestContactCount::test_pixel_warning
  /home/sroet/miniconda3/envs/contact_map/lib/python3.9/site-packages/_pytest/python.py:192: PytestRemovedIn8Warning: Passing None has been deprecated.
  See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.
    result = testfunction(**testargs)
```

This updates the "no warning" check to the new recommendation in [that link](https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests)