### PR TITLE
fix matplotlib 3.6 'Unable to determine Axes to steal space for Colorbar

### DIFF
--- a/contact_map/plot_utils.py
+++ b/contact_map/plot_utils.py
@@ -22,6 +22,7 @@ _SEQUENTIAL = [
     'afmhot', 'gist_heat', 'copper'
 ]
 
+
 def is_cmap_diverging(cmap):
     if cmap in _DIVERGING:
         return True
@@ -30,6 +31,7 @@ def is_cmap_diverging(cmap):
     else:
         warnings.warn("Unknown colormap: Treating as sequential.")
         return False
+
 
 def ranged_colorbar(cmap, norm, cbmin, cbmax, ax=None):
     """Create a colorbar with given endpoints.
@@ -60,6 +62,7 @@ def ranged_colorbar(cmap, norm, cbmin, cbmax, ax=None):
 
     if ax is None:
         fig = plt
+        ax = plt.gca()
     else:
         fig = ax.figure
 


### PR DESCRIPTION
With the release of matplotlib `3.6.0` we triggered an error because we relied on [deprecated behavior](https://github.com/matplotlib/matplotlib/blob/d04c8de4a89ab756a137ef146e8542e81041909f/lib/matplotlib/figure.py#L1182-L1191)
(We did not trigger the deprecation warning as our `mappable` does not have the attribute `axes`)

This reinstates the old behavior (grabbing the current `axes` via `plt.gca()`)