### PR TITLE
Update RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,14 @@
 version: 2
 
-#conda:
-    #environment: docs/environment.yml
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3.11
 
 python:
     install:
       - requirements: docs/rtd_requirements.txt
-      #- requirements: requirements.txt
       - requirements: docs/requirements.txt
       - method: setuptools
         path: .
-      #- method: pip
-        #path: .
-    #system_packages: false
-
+    system_packages: false


### PR DESCRIPTION
Apparently docs were not building correctly, and furthermore, we had some setting to use system packages, which will no longer be allowed.

Let's get that fixed.