### PR TITLE
tests: `setup`,`teardown` -> `setup_method`, etc

### DIFF
--- a/contact_map/tests/test_concurrence.py
+++ b/contact_map/tests/test_concurrence.py
@@ -65,7 +65,7 @@ class ContactConcurrenceTester(object):
 
 
 class TestAtomContactConcurrence(ContactConcurrenceTester):
-    def setup(self):
+    def setup_method(self):
         self.concurrence = AtomContactConcurrence(
             trajectory=traj,
             atom_contacts=contacts.atom_contacts.most_common(),
@@ -105,7 +105,7 @@ class TestAtomContactConcurrence(ContactConcurrenceTester):
 
 
 class TestResidueContactConcurrence(ContactConcurrenceTester):
-    def setup(self):
+    def setup_method(self):
         self.heavy_contact_concurrence = ResidueContactConcurrence(
             trajectory=traj,
             residue_contacts=contacts.residue_contacts.most_common(),
@@ -157,7 +157,7 @@ class TestResidueContactConcurrence(ContactConcurrenceTester):
 
 
 class TestConcurrencePlotter(object):
-    def setup(self):
+    def setup_method(self):
         self.concurrence = ResidueContactConcurrence(
             trajectory=traj,
             residue_contacts=contacts.residue_contacts.most_common(),

--- a/contact_map/tests/test_contact_count.py
+++ b/contact_map/tests/test_contact_count.py
@@ -14,7 +14,7 @@ from .test_contact_map import (traj, traj_atom_contact_count,
 from contact_map.contact_count import *
 
 class TestContactCount(object):
-    def setup(self):
+    def setup_method(self):
         self.map = ContactFrequency(traj, cutoff=0.075,
                                     n_neighbors_ignored=0)
         self.topology = self.map.topology

--- a/contact_map/tests/test_contact_count.py
+++ b/contact_map/tests/test_contact_count.py
@@ -65,8 +65,7 @@ class TestContactCount(object):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             self.atom_contacts.plot(figsize=(5, 5), dpi=2)
-        # See if no warning was raised
-        assert len(record) == 0
+            # should convert to error if warning issued
 
         # Now raise the warning as 4*2 < 10
         with pytest.warns(RuntimeWarning) as record:

--- a/contact_map/tests/test_contact_count.py
+++ b/contact_map/tests/test_contact_count.py
@@ -62,7 +62,8 @@ class TestContactCount(object):
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason="Missing matplotlib")
     def test_pixel_warning(self):
         # This should not raise a warning (5*2>=10)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             self.atom_contacts.plot(figsize=(5, 5), dpi=2)
         # See if no warning was raised
         assert len(record) == 0

--- a/contact_map/tests/test_contact_map.py
+++ b/contact_map/tests/test_contact_map.py
@@ -117,7 +117,7 @@ class TestContactObject(object):
     # note: these used to be the tests for the separate single-frame
     # ContactMap class; however, it includes a lot of good unit tests for
     # ContactObject
-    def setup(self):
+    def setup_method(self):
         self.topology = traj.topology
         self.map0 = ContactFrequency(traj[0], cutoff=0.075,
                                      n_neighbors_ignored=0)
@@ -336,7 +336,7 @@ class TestContactObject(object):
 
 
 class TestContactFrequency(object):
-    def setup(self):
+    def setup_method(self):
         self.atoms = [0, 1, 4, 5, 6, 7, 8, 9]
         self.map = ContactFrequency(trajectory=traj,
                                     cutoff=0.075,

--- a/contact_map/tests/test_contact_trajectory.py
+++ b/contact_map/tests/test_contact_trajectory.py
@@ -31,7 +31,7 @@ TRAJ_RES_CONTACTS = [
 ]
 
 class TestContactTrajectory(object):
-    def setup(self):
+    def setup_method(self):
         self.traj = md.load(find_testfile("trajectory.pdb"))
         self.map = ContactTrajectory(self.traj, cutoff=0.075,
                                      n_neighbors_ignored=0)
@@ -175,7 +175,7 @@ class TestContactTrajectory(object):
 
 
 class TestMutableContactTrajectory(object):
-    def setup(self):
+    def setup_method(self):
         self.traj = md.load(find_testfile("trajectory.pdb"))
         self.map = MutableContactTrajectory(self.traj, cutoff=0.075,
                                             n_neighbors_ignored=0)
@@ -223,7 +223,7 @@ class TestMutableContactTrajectory(object):
 
 
 class TestWindowedIterator(object):
-    def setup(self):
+    def setup_method(self):
         self.iter = WindowedIterator(length=10, width=3, step=2,
                                      slow_build=False)
 
@@ -286,7 +286,7 @@ class TestWindowedIterator(object):
 
 
 class TestRollingContactFrequency(object):
-    def setup(self):
+    def setup_method(self):
         self.traj = md.load(find_testfile("trajectory.pdb"))
         self.map = ContactTrajectory(self.traj, cutoff=0.075,
                                      n_neighbors_ignored=0)

--- a/contact_map/tests/test_dask_runner.py
+++ b/contact_map/tests/test_dask_runner.py
@@ -29,7 +29,7 @@ def dask_setup_test_cluster(distributed, n_workers=4, n_attempts=3):
 
 
 class TestDaskRunners(object):
-    def setup(self):
+    def setup_method(self):
         dask = pytest.importorskip('dask')  # pylint: disable=W0612
         distributed = pytest.importorskip('dask.distributed')
         self.distributed = distributed
@@ -39,7 +39,7 @@ class TestDaskRunners(object):
         self.client = distributed.Client(self.cluster)
         self.filename = find_testfile("trajectory.pdb")
 
-    def teardown(self):
+    def teardown_method(self):
         self.client.shutdown()
 
     @pytest.mark.parametrize("dask_cls", [DaskContactFrequency,

--- a/contact_map/tests/test_frequency_task.py
+++ b/contact_map/tests/test_frequency_task.py
@@ -33,7 +33,7 @@ class TestSlicing(object):
         assert default_slices(n_total, n_workers) == results
 
 class TestTasks(object):
-    def setup(self):
+    def setup_method(self):
         self.contact_freq_0_4 = ContactFrequency(traj[:4], cutoff=0.075,
                                                  n_neighbors_ignored=0)
         self.contact_freq_4 = ContactFrequency(traj[4], cutoff=0.075,

--- a/contact_map/tests/test_min_dist.py
+++ b/contact_map/tests/test_min_dist.py
@@ -14,7 +14,7 @@ traj = md.load(find_testfile("trajectory.pdb"))
 
 @pytest.mark.parametrize("idx", [0, 4])
 class TestNearestAtoms(object):
-    def setup(self):
+    def setup_method(self):
         self.nearest_atoms = {
             idx: NearestAtoms(traj, cutoff=0.075, frame_number=idx)
             for idx in [0, 4]
@@ -107,7 +107,7 @@ class TestNearestAtoms(object):
 
 
 class TestMinimumDistanceCounter(object):
-    def setup(self):
+    def setup_method(self):
         self.topology = traj.topology
         query = [4, 5]
         haystack = list(set(range(10)) - set(query))

--- a/contact_map/tests/test_plot_utils.py
+++ b/contact_map/tests/test_plot_utils.py
@@ -72,7 +72,7 @@ def test_is_cmap_diverging(cmap):
 
 
 class TestContactRange(object):
-    def setup(self):
+    def setup_method(self):
         self.cr = _ContactPlotRange(5)
 
     @pytest.mark.parametrize("case", [(_ContactPlotRange(5), True),


### PR DESCRIPTION
Pytest prefers (and now, apparently requires) the use of `setup_method` instead of `setup`.

Looks like there was also a problem to fix about newer pytest not liking `pytest.warns(None)` as a way to indicate that no warnings were issued.