### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
+          - "3.13"
           - "3.12"
           - "3.11"
-          - "3.10"
         OS: ["ubuntu"]
         MDTRAJ: ["mdtraj-release"]
         INSTALL_WITH: ["pip"]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,22 +23,22 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
-          - 3.9
-          - 3.8
-          - 3.7
+          - "3.12"
+          - "3.11"
+          - "3.10"
         OS: ["ubuntu"]
         MDTRAJ: ["mdtraj-release"]
         INSTALL_WITH: ["pip"]
         include:
-          - CONDA_PY: 3.9
+          - CONDA_PY: "3.12"
             OS: "ubuntu"
             MDTRAJ: "mdtraj-dev"
             INSTALL_WITH: "pip"
-          - CONDA_PY: 3.9
+          - CONDA_PY: "3.12"
             OS: "windows"
             MDTRAJ: "mdtraj-release"
             INSTALL_WITH: "conda"
-          - CONDA_PY: 3.7
+          - CONDA_PY: "3.10"
             OS: "windows"
             MDTRAJ: "mdtraj-release"
             INSTALL_WITH: "conda"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,15 +30,15 @@ jobs:
         MDTRAJ: ["mdtraj-release"]
         INSTALL_WITH: ["pip"]
         include:
-          - CONDA_PY: "3.12"
+          - CONDA_PY: "3.13"
             OS: "ubuntu"
             MDTRAJ: "mdtraj-dev"
             INSTALL_WITH: "pip"
-          - CONDA_PY: "3.12"
+          - CONDA_PY: "3.13"
             OS: "windows"
             MDTRAJ: "mdtraj-release"
             INSTALL_WITH: "conda"
-          - CONDA_PY: "3.10"
+          - CONDA_PY: "3.11"
             OS: "windows"
             MDTRAJ: "mdtraj-release"
             INSTALL_WITH: "conda"


### PR DESCRIPTION
Aside from being overdue and needed, this is largely in response to a CI failure due to a change in mdtraj-dev. If this is just that our Python CI is out of date, then the problem is on us. If we're still failing after this PR, then we'll take it upstream.