### PR TITLE
Wrap json strings in io.StringIO in deserialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ docs/_build/
 
 # PyBuilder
 target/
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/contact_map/contact_map.py
+++ b/contact_map/contact_map.py
@@ -6,6 +6,7 @@ Contact map analysis.
 import collections
 import itertools
 import pickle
+import io
 import json
 
 import warnings
@@ -273,7 +274,7 @@ class ContactObject(object):
     def _deserialize_topology(topology_json):
         """Create MDTraj topology from JSON-serialized version"""
         table, bonds = json.loads(topology_json)
-        topology_df = pd.read_json(table)
+        topology_df = pd.read_json(io.StringIO(table))
         topology = md.Topology.from_dataframe(topology_df,
                                               np.array(bonds))
         return topology


### PR DESCRIPTION
Looks like pandas 3.0 has changed things so that it prefers `read_json` to think its input is a filename; we've been assuming it was the contents of that file. Hoping this fixes (had trouble reproducing locally for some reason?)